### PR TITLE
fix: remove all @ts-ignore suppressions in favor of proper typing

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -160,7 +160,6 @@
 	}
 
 	window.addEventListener('languageChange', (e) => {
-		// @ts-ignore
 		updateCTA(e.detail.language);
 	});
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -187,7 +187,6 @@ function updateFooter(lang: string) {
 }
 
 window.addEventListener('languageChange', (e) => {
-	// @ts-ignore
 	updateFooter(e.detail.language);
 });
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -135,9 +135,7 @@ const textLinks: { label: string; href: string; key: string }[] = [
 		es: { home: 'Inicio', work: 'Proyectos', about: 'Acerca de', navCta: 'Hablemos' },
 	};
 
-	// @ts-ignore
-	function updateNav(lang) {
-		// @ts-ignore
+	function updateNav(lang: 'en' | 'es') {
 		const t = lang === 'es' ? navT.es : navT.en;
 		(['home', 'work', 'about', 'navCta'] as const).forEach((k) => {
 			document.querySelectorAll(`[data-translate="${k}"], [data-translate="m-${k}"]`).forEach((el) => {
@@ -147,7 +145,6 @@ const textLinks: { label: string; href: string; key: string }[] = [
 	}
 
 	window.addEventListener('languageChange', (e) => {
-		// @ts-ignore
 		updateNav(e.detail.language);
 	});
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,6 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface WindowEventMap {
+	languageChange: CustomEvent<{ language: 'en' | 'es' }>;
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -887,7 +887,6 @@ import Icon from '../components/Icon.astro';
 	}
 
 	window.addEventListener('languageChange', (e) => {
-		// @ts-ignore
 		updateAboutLanguage(e.detail.language);
 	});
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -104,8 +104,7 @@ const projects = allProjects
 					{
 						projects.map((project, idx) => {
 							const spanishId = project.id.includes('.md') ? project.id.replace('.md', '-es.md') : `${project.id}-es`;
-							// @ts-ignore
-							const spanishProject = allProjects.find((p) => p.id === spanishId || p.slug === `${project.slug}-es`);
+							const spanishProject = allProjects.find((p) => p.id === spanishId);
 							const slot = `slot-${idx + 1}`;
 							return (
 								<li class:list={['project-item', slot]} data-en-slug={project.id} data-es-slug={spanishId}>
@@ -1582,7 +1581,6 @@ const projects = allProjects
 	}
 
 	window.addEventListener('languageChange', (e) => {
-		// @ts-ignore
 		updateHomeLanguage(e.detail.language);
 	});
 

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -29,8 +29,7 @@ const featuredProjects = uniqueProjects.slice(0, 3);
 				{
 					featuredProjects.map((project) => {
 						const spanishId = project.id.includes('.md') ? project.id.replace('.md', '-es.md') : `${project.id}-es`;
-						// @ts-ignore
-						const spanishProject = allProjects.find((p) => p.id === spanishId || p.slug === `${project.slug}-es`);
+						const spanishProject = allProjects.find((p) => p.id === spanishId);
 						return (
 							<li class="project-item" data-en-slug={project.id} data-es-slug={spanishId}>
 								<div class="project-en" style="display: block;">
@@ -132,7 +131,6 @@ const featuredProjects = uniqueProjects.slice(0, 3);
 		const language = localStorage.getItem('language') || (navigator.language.startsWith('es') ? 'es' : 'en');
 		translateWorkPage(language);
 		window.addEventListener('languageChange', (e) => {
-			// @ts-ignore
 			translateWorkPage(e.detail.language);
 		});
 	</script>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -16,7 +16,6 @@ interface Props {
 // https://docs.astro.build/en/core-concepts/routing/#dynamic-routes
 export async function getStaticPaths() {
 	const work = await getCollection('work');
-	// @ts-ignore
 	return work.map((entry) => ({
 		params: { slug: entry.id },
 		props: { entry },
@@ -40,7 +39,6 @@ const { entry } = Astro.props;const { Content } = await render(entry);
 						<Hero title={entry.data.title} align="start" />
 						<p class="description">{entry.data.description}</p>
 						<div class="tags">
-							{/* @ts-ignore */}
 							{entry.data.tags.map((t) => {
 								let cat = 'dev';
 								if (t.toLowerCase().includes('design') || t.toLowerCase().includes('ui') || t.toLowerCase().includes('ux')) cat = 'design';


### PR DESCRIPTION
## Summary
- Type the `languageChange` CustomEvent via a `WindowEventMap` augmentation in `src/env.d.ts`, eliminating 6 `@ts-ignore` comments that were silencing `e.detail` access across Nav, Footer, ContactCTA, about, index and work pages.
- Drop the dead `p.slug` fallback in the ES/EN project lookup (`CollectionEntry` has no `slug` property; `id`-based matching already covers the `-es.md` naming convention).
- Remove 2 `@ts-ignore` comments in `work/[...slug].astro` that were confirmed to suppress nothing (removing them produces zero new type errors).

All 12 `@ts-ignore` in the codebase are now gone, verified with `astro check` (0 errors) and `astro build` (12 pages generated successfully).

## Test plan
- [x] `astro check` passes with 0 errors/warnings
- [x] `astro build` completes and generates all 12 expected pages (including `-es.md` routes)
- [x] Manually verified in browser: home, `/work/`, and a project detail page load with 0 console errors
- [x] Manually verified language toggle (EN/ES) updates nav and content correctly on home page
- [x] Manually verified EN/ES cross-links between project cards still resolve to the correct `-es.md` slugs