### PR TITLE
Redesign project detail pages with case-study layout

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,32 @@ const workCollection = defineCollection({
     img_alt: z.string().optional(),
     description: z.string(),
     tags: z.array(z.string()),
+    liveUrl: z.url().optional(),
+    githubUrl: z.url().optional(),
+    problem: z.string(),
+    solution: z.object({
+      intro: z.string().optional(),
+      columns: z.array(
+        z.object({
+          title: z.string(),
+          items: z.array(z.string()),
+        })
+      ).min(1).max(2),
+    }),
+    techStack: z.array(
+      z.object({
+        category: z.string(),
+        items: z.array(z.string()),
+      })
+    ),
+    architecture: z.object({
+      code: z.string(),
+      description: z.string(),
+    }).optional(),
+    outcome: z.object({
+      highlights: z.array(z.string()).optional(),
+      steps: z.array(z.string()),
+    }),
   }),
 });
 

--- a/src/content/work/AstroLinkHub-es.md
+++ b/src/content/work/AstroLinkHub-es.md
@@ -9,36 +9,28 @@ tags:
   - Diseño
   - Desarrollo
   - Astro
+liveUrl: https://amonsalv.netlify.app
+githubUrl: https://github.com/amonsalv/AstroLink
+problem: |
+  Una página de enlaces al estilo Linktree — gratuita para auto-hospedar, totalmente personalizable desde un único archivo de configuración JSON en vez de editar el markup a mano en cada cambio de perfil.
+solution:
+  columns:
+    - title: Qué hace
+      items:
+        - Colores, degradados de fondo, imagen de cabecera, nombre y descripción personalizables
+        - Íconos y botones sociales que enlazan a tus perfiles, editables vía JSON
+        - Enlaces destacados resaltados con una imagen de fondo o color
+        - Íconos provenientes de la librería Astro Icons
+techStack:
+  - category: Stack
+    items:
+      - Astro
+      - TypeScript
+      - CSS
+outcome:
+  steps:
+    - Editas las secciones html, background y header en el JSON de configuración
+    - Añades íconos y botones sociales para tus propios perfiles
+    - Destacas enlaces con una imagen de fondo o color
+    - Despliegas gratis — sin backend, sin complejidad de build
 ---
-
-## Intención del Proyecto
-
-AstroLinkHub te permite crear una página de enlaces personalizable de forma gratuita, usando tus colores preferidos y créditos. Actualízala fácilmente usando JSON.
-
-## Tecnologías Utilizadas
-
-El proyecto ha sido desarrollado usando las siguientes tecnologías:
-
-- **Astro**: Un framework de desarrollo de aplicaciones web de código abierto basado en TypeScript.
-- **CSS**: Utilizado para dar estilo y diseño a las páginas web.
-- **TypeScript**: Un lenguaje de programación basado en JavaScript que añade características adicionales, como tipado estático, proporcionando mayor robustez al código.
-
-## Estructura del Repositorio
-
-El repositorio está organizado de la siguiente manera:
-
-- **html** -> Edita el idioma, título, descripción y favicon (reemplázalo en `/public`).
-- **background** -> Usa el mismo color dos veces para un color sólido o usa dos colores para un color degradado.
-- **header** -> Edita tu imagen (reemplázala en `/public`), nombre y descripción.
-- **socials** -> Añade más íconos con tus URLs de redes sociales (mira las redes disponibles).
-- **featured** -> Destaca enlaces con una imagen de fondo o color (igual que los botones).
-- **buttons** -> Añade más botones con tus URLs de redes sociales (mira las redes disponibles).
-- **footer** -> Edita el copyright y URL del desarrollador.
-
-##### Íconos:
-Los íconos ahora provienen de la librería Astro Icons. Puedes encontrar los íconos disponibles y sus instrucciones de uso en la [documentación de Astro Icons](https://astro.build/icons).
-
-#### Puedes encontrar el proyecto en los siguientes enlaces
-
-- Sitio web del proyecto: https://amonsalv.netlify.app
-- Repositorio del proyecto: https://github.com/amonsalv/AstroLink

--- a/src/content/work/AstroLinkHub.md
+++ b/src/content/work/AstroLinkHub.md
@@ -9,41 +9,28 @@ tags:
   - Design
   - Dev
   - Astro
+liveUrl: https://amonsalv.netlify.app
+githubUrl: https://github.com/amonsalv/AstroLink
+problem: |
+  A Linktree-style personal links page — free to self-host, fully customizable through a single JSON config file instead of hand-editing markup for every profile change.
+solution:
+  columns:
+    - title: What it does
+      items:
+        - Customizable colors, background gradients, header image, name, and description
+        - Social icons and buttons that link out to your profiles, editable via JSON
+        - Featured links highlighted with a background image or color
+        - Icons sourced from the Astro Icons library
+techStack:
+  - category: Stack
+    items:
+      - Astro
+      - TypeScript
+      - CSS
+outcome:
+  steps:
+    - Edit the html, background, and header sections in the JSON config
+    - Add social icons and buttons for your own profiles
+    - Highlight featured links with a background image or color
+    - Deploy for free — no backend, no build complexity
 ---
-
-## Intention of the Project
-
-AstroLinkHub allows you to create a customizable links page for free, using your preferred colors and credits. Easily update it using JSON.
-
-
-## Technologies Used
-
-The project has been developed using the following technologies:
-
-- **Astro**: An open source web application development framework based on TypeScript. .
-- **CSS**: Used to style and design web pages.
-- **TypeScript**: A programming language based on JavaScript that adds additional features, such as static typing, providing greater robustness to the code.
-
-## Repository Structure
-
-The repository is organized as follows:
-
-- **html** -> Edit language, title, description and favicon (replace it in `/public`).
-- **background** -> Use the same color twice for a solid color or use two colors for a gradient color.
-- **header** -> Edit your image (replace it in `/public`), name and description.
-- **socials** -> Add more icons with your socials URL (see the networks available).
-- **featured** -> Highlight links with a background image or color (same as buttons).
-- **buttons** -> Add more buttons with your socials URL (see the networks available).
-- **footer** -> Edit the copyright and URL of the developer.
-
-##### Icons:
-Icons are now sourced from the Astro Icons library. You can find the available icons and their usage instructions in the [Astro Icons documentation](https://astro.build/icons).
-
-
-#### You can find the project at the following links
-
-- Project website: https://amonsalv.netlify.app
-- Project repository: https://github.com/amonsalv/AstroLink
-
-
-

--- a/src/content/work/bakery-buen-corazon-es.md
+++ b/src/content/work/bakery-buen-corazon-es.md
@@ -1,6 +1,6 @@
 ---
 title: Repostería Buen Corazón
-publishDate: 2022-03-04 
+publishDate: 2022-03-04
 img: /assets/stock-3.jpg
 img_alt: Una vitrina en una panadería artesanal mostrando una variedad de postres, incluyendo donas decoradas con glaseado, crema y varios ingredientes
 description: |
@@ -11,28 +11,27 @@ tags:
   - HTML
   - CSS
   - JavaScript
+liveUrl: https://amonsalv.github.io/Panaderia/
+githubUrl: https://github.com/amonsalv/Panaderia
+problem: |
+  Repostería Buen Corazón necesitaba mostrar sus productos artesanales en línea y permitir a los clientes navegar, agregar al carrito y comprar sin la fricción de una tienda puramente presencial.
+solution:
+  columns:
+    - title: Qué hace
+      items:
+        - Navega el catálogo completo de productos desde la página principal
+        - Ve información detallada de cada producto bajo demanda
+        - Agrega productos al carrito de compras y revísalo antes de pagar
+        - Regístrate para una experiencia personalizada como cliente recurrente
+techStack:
+  - category: Frontend
+    items:
+      - HTML
+      - CSS
+      - JavaScript
+outcome:
+  steps:
+    - El cliente navega el catálogo de productos en la página principal
+    - Los detalles del producto se abren al hacer clic, el carrito se actualiza en vivo
+    - Los usuarios registrados obtienen una experiencia personalizada entre visitas
 ---
-
-## Intención del Proyecto
-
-Este proyecto fue creado para mostrar los productos de panadería artesanal de Repostería Buen Corazón y proporcionar una experiencia interactiva para los usuarios. La aplicación web fue diseñada para ofrecer una experiencia de compra fluida, permitiendo a los usuarios navegar por los productos, ver información detallada y gestionar su carrito de compras con facilidad. Al incorporar autenticación de usuario, el proyecto también tiene como objetivo ofrecer una experiencia personalizada para clientes recurrentes.
-
-## Uso
-
-- **Ver Productos**: Navega por los productos mostrados en la página principal.
-- **Detalles del Producto**: Haz clic en el botón "Inicia" para ver información detallada sobre un producto.
-- **Agregar al Carrito**: Haz clic en el botón "Agregar al Carrito" para añadir un producto a tu carrito de compras.
-- **Ver Carrito**: Haz clic en el ícono del carrito para ver los productos en tu carrito.
-- **Registro de Usuario**: Llena el formulario de registro para crear una cuenta.
-
-## Estructura del Proyecto
-
-- `index.html`: El archivo HTML principal que contiene la estructura de la aplicación web.
-- `js/controladortienda.js`: Contiene la lógica principal para manejar las interacciones de productos y el carrito de compras.
-- `js/amplianinfo.js`: Contiene la función para mostrar información detallada del producto.
-- `js/llenadotienda.js`: Contiene la función para poblar la tienda con productos.
-
-#### Puedes encontrar el proyecto en los siguientes enlaces
-
-- Sitio web del proyecto: https://amonsalv.github.io/Panaderia/
-- Repositorio del proyecto: https://github.com/amonsalv/Panaderia

--- a/src/content/work/bakery-buen-corazon.md
+++ b/src/content/work/bakery-buen-corazon.md
@@ -1,39 +1,37 @@
 ---
 title: Repostrería Buen Corazón
-publishDate: 2022-03-04 
+publishDate: 2022-03-04
 img: /assets/stock-3.jpg
 img_alt: A display case in an artisanal bakery showing a variety of desserts, including donuts decorated with icing, cream, and various toppings
 description: |
   Repostrería Buen Corazón is an artisanal bakery, offering products that are 100% handmade with love. This project is a web application that showcases our products and allows users to interact with our store.
-
 tags:
   - Design
   - Dev
   - Html
   - CSS
   - JavaScript
+liveUrl: https://amonsalv.github.io/Panaderia/
+githubUrl: https://github.com/amonsalv/Panaderia
+problem: |
+  Repostrería Buen Corazón needed a way to showcase its artisanal bakery products online and let customers browse, add to cart, and check out without the friction of a purely in-person shop.
+solution:
+  columns:
+    - title: What it does
+      items:
+        - Browse the full product catalog from the main page
+        - View detailed product information on demand
+        - Add products to a shopping cart and review it before checkout
+        - Register an account for a personalized, returning-customer experience
+techStack:
+  - category: Frontend
+    items:
+      - HTML
+      - CSS
+      - JavaScript
+outcome:
+  steps:
+    - Customer browses the product catalog on the main page
+    - Product details open on click, cart updates live as items are added
+    - Registered users get a personalized shopping experience across visits
 ---
-
-## Intention of the Project
-
-This project was created to showcase the artisanal bakery products of Repostrería Buen Corazón and to provide an interactive experience for users. The web application was designed to offer a seamless shopping experience, allowing users to browse products, view detailed information, and manage their shopping cart with ease. By incorporating user authentication, the project also aims to offer a personalized experience for returning customers.
-
-## Usage
-
-- **Viewing Products**: Browse through the products displayed on the main page.
-- **Product Details**: Click on the "Inicia" button to view detailed information about a product.
-- **Add to Cart**: Click on the "Agregar al Carrito" button to add a product to your shopping cart.
-- **View Cart**: Click on the cart icon to view the products in your cart.
-- **User Registration**: Fill out the registration form to create an account.
-
-## Project Structure
-
-- `index.html`: The main HTML file that contains the structure of the web application.
-- `js/controladortienda.js`: Contains the main logic for handling product interactions and the shopping cart.
-- `js/amplianinfo.js`: Contains the function to display detailed product information.
-- `js/llenadotienda.js`: Contains the function to populate the store with products.
-
-#### You can find the project at the following links
-
-- Project website: https://amonsalv.github.io/Panaderia/
-- Project repository: https://github.com/amonsalv/Panaderia

--- a/src/content/work/ordenary-es.md
+++ b/src/content/work/ordenary-es.md
@@ -12,29 +12,46 @@ tags:
   - Spring Boot
   - Firebase
   - PostgreSQL
+problem: |
+  Telas 3B se construyó para una sola empresa textil. Mientras lo mantenía, la misma forma seguía apareciendo: las órdenes avanzan por etapas, los operarios toman tareas, el inventario se controla, sin importar realmente qué fabricara o vendiera el negocio. Ordenary es lo que pasa cuando esa observación se convierte en producto: en lugar de un sistema para un solo cliente, un core universal de Orden/Tarea/Item/Operario/Cliente que cada workspace re-etiqueta a su propia industria mediante un IndustryProfile — textil, taller, restaurante, construcción y más.
+solution:
+  columns:
+    - title: Qué hace
+      items:
+        - Workspaces multi-tenant, cada uno hablando el idioma de su industria sobre el mismo modelo subyacente
+        - Órdenes, tareas, inventario y clientes gestionados desde un único dashboard, con vistas diferenciadas por rol para administradores y operarios
+        - Reportes, notificaciones y alertas de stock bajo construidos sobre la misma data central
+        - Autenticación con Firebase frente a una API protegida con Spring Security
+techStack:
+  - category: Frontend
+    items:
+      - React 18
+      - TypeScript
+      - Vite
+      - Zustand
+      - Firebase Auth
+      - Axios
+      - Recharts
+  - category: Backend
+    items:
+      - Java 17
+      - Spring Boot 3
+      - Spring Security
+      - Spring Data JPA
+      - PostgreSQL
+      - Flyway
+      - Bucket4j
+  - category: Testing
+    items:
+      - Vitest — 290 tests en 62 archivos
+      - Storybook para la librería de componentes
+  - category: Infraestructura
+    items:
+      - Docker Compose (PostgreSQL + backend)
+outcome:
+  steps:
+    - Core de Orden/Tarea/Item/Operario/Cliente construido y re-etiquetando correctamente entre perfiles de industria.
+    - Frontend en migración progresiva de una arquitectura de estilos BEM legacy hacia Tailwind CSS, componente por componente.
+    - "290 tests en 62 archivos sostienen la superficie multi-tenant mientras crece."
+    - El frontend corre en local contra un backend dockerizado; el despliegue a producción es el siguiente paso.
 ---
-
-## Cómo empezó
-
-Telas 3B se construyó para una sola empresa textil. Mientras lo mantenía, la misma forma seguía apareciendo: las órdenes avanzan por etapas, los operarios toman tareas, el inventario se controla, sin importar realmente qué fabricara o vendiera el negocio. Ordenary es lo que pasa cuando esa observación se convierte en producto: en lugar de un sistema para un solo cliente, un core universal de Orden/Tarea/Item/Operario/Cliente que cada workspace re-etiqueta a su propia industria mediante un `IndustryProfile` — textil, taller, restaurante, construcción y más.
-
-## Qué hace
-
-- Workspaces multi-tenant, cada uno hablando el idioma de su industria sobre el mismo modelo subyacente
-- Órdenes, tareas, inventario y clientes gestionados desde un único dashboard, con vistas diferenciadas por rol para administradores y operarios
-- Reportes, notificaciones y alertas de stock bajo construidos sobre la misma data central
-- Autenticación con Firebase frente a una API protegida con Spring Security
-
-## Stack tecnológico
-
-**Frontend:** React 18, TypeScript, Vite, Zustand, Firebase Auth, Axios, Recharts — en migración progresiva de una arquitectura de estilos BEM legacy hacia Tailwind CSS, componente por componente.
-
-**Backend:** Java 17, Spring Boot 3, Spring Security, Spring Data JPA, PostgreSQL con migraciones Flyway, rate limiting con Bucket4j.
-
-**Testing:** Vitest, 290 tests en 62 archivos; Storybook para la librería de componentes.
-
-**Infraestructura:** Docker Compose para PostgreSQL + backend.
-
-## En qué punto está
-
-Todavía en desarrollo activo — sin desplegar en ningún lado por ahora. El frontend corre en local contra un backend dockerizado mientras resuelvo las partes que un proyecto de un solo cliente como Telas 3B nunca me obligó a resolver: multi-tenancy, un modelo de dominio agnóstico de industria, y una suite de tests que tiene que sostenerse a medida que crece la superficie del producto. El despliegue a producción es el siguiente paso.

--- a/src/content/work/ordenary.md
+++ b/src/content/work/ordenary.md
@@ -12,29 +12,46 @@ tags:
   - Spring Boot
   - Firebase
   - PostgreSQL
+problem: |
+  Telas 3B was built for one textile company. While maintaining it, the same shape kept showing up — orders move through stages, operators pick up tasks, inventory gets tracked — regardless of what the business actually made or sold. Ordenary is what happens when that observation becomes the product: instead of a system for one client, a universal Order/Task/Item/Operator/Client core that each workspace relabels to its own industry through an IndustryProfile — textile, workshop, restaurant, construction, and beyond.
+solution:
+  columns:
+    - title: What it does
+      items:
+        - Multi-tenant workspaces, each speaking its own industry's language over the same underlying model
+        - Orders, tasks, inventory and clients managed from a single dashboard, with role-based views for admins and operators
+        - Reports, notifications, and low-stock alerts built on top of the same core data
+        - Firebase authentication in front of a Spring Security-protected API
+techStack:
+  - category: Frontend
+    items:
+      - React 18
+      - TypeScript
+      - Vite
+      - Zustand
+      - Firebase Auth
+      - Axios
+      - Recharts
+  - category: Backend
+    items:
+      - Java 17
+      - Spring Boot 3
+      - Spring Security
+      - Spring Data JPA
+      - PostgreSQL
+      - Flyway
+      - Bucket4j
+  - category: Testing
+    items:
+      - Vitest — 290 tests across 62 files
+      - Storybook component library
+  - category: Infra
+    items:
+      - Docker Compose (PostgreSQL + backend)
+outcome:
+  steps:
+    - Core Order/Task/Item/Operator/Client model built and relabeling correctly across industry profiles.
+    - Frontend mid-migration from a legacy BEM stylesheet architecture to Tailwind CSS, component by component.
+    - "290 tests across 62 files keep the multi-tenant surface honest as it grows."
+    - Frontend runs locally against a Dockerized backend; production deployment is next.
 ---
-
-## How it started
-
-Telas 3B was built for one textile company. While maintaining it, the same shape kept showing up — orders move through stages, operators pick up tasks, inventory gets tracked — regardless of what the business actually made or sold. Ordenary is what happens when that observation becomes the product: instead of a system for one client, a universal Order/Task/Item/Operator/Client core that each workspace relabels to its own industry through an `IndustryProfile` — textile, workshop, restaurant, construction, and beyond.
-
-## What it does
-
-- Multi-tenant workspaces, each speaking its own industry's language over the same underlying model
-- Orders, tasks, inventory and clients managed from a single dashboard, with role-based views for admins and operators
-- Reports, notifications, and low-stock alerts built on top of the same core data
-- Firebase authentication in front of a Spring Security-protected API
-
-## Tech stack
-
-**Frontend:** React 18, TypeScript, Vite, Zustand, Firebase Auth, Axios, Recharts — mid-migration from a legacy BEM stylesheet architecture to Tailwind CSS, component by component.
-
-**Backend:** Java 17, Spring Boot 3, Spring Security, Spring Data JPA, PostgreSQL with Flyway migrations, Bucket4j rate limiting.
-
-**Testing:** Vitest, 290 tests across 62 files; Storybook for the component library.
-
-**Infra:** Docker Compose for PostgreSQL + backend.
-
-## Where it's at
-
-Still in active development — not deployed anywhere yet. The frontend runs locally against a Dockerized backend while I work through the parts a single-client project like Telas 3B never forced me to solve: multi-tenancy, an industry-agnostic domain model, and a test suite that has to hold as the surface area grows. Production deployment is next.

--- a/src/content/work/quinbaya-hotels-es.md
+++ b/src/content/work/quinbaya-hotels-es.md
@@ -10,33 +10,29 @@ tags:
   - Desarrollo
   - Angular
   - TypeScript
+liveUrl: https://hotelesquimbaya.vercel.app/
+githubUrl: https://github.com/amonsalv/hotelesquimbaya
+problem: |
+  Un proyecto de curso en el CESDE: construir una experiencia de reservas al estilo Airbnb — buscar, reservar y gestionar habitaciones de hotel — respaldada por una API real para operaciones CRUD sobre reservas. Desarrollado completamente en Angular con TypeScript para una mejor organización de componentes, con la guía de mi profesor Juan José Gallego.
+solution:
+  columns:
+    - title: Qué hace
+      items:
+        - Navega cabañas y habitaciones de distintas propiedades de Quimbaya
+        - Ve disponibilidad e información detallada de cada habitación
+        - Crea una reserva a través de un formulario validado
+        - Gestiona o cancela reservas existentes a través de la API
+techStack:
+  - category: Frontend
+    items:
+      - Angular
+      - TypeScript
+      - HTML
+      - CSS
+outcome:
+  steps:
+    - El usuario navega las cabañas y habitaciones disponibles
+    - El usuario revisa detalles y disponibilidad de la habitación
+    - El usuario envía una reserva a través de un formulario validado
+    - La reserva se crea mediante una llamada CRUD a la API y puede gestionarse después
 ---
-
-> Quiero agradecer a mi profesor Juan José Gallego, por ayudarnos a crear este proyecto, su paciencia para enseñar y su conocimiento.
-
-## Intención del Proyecto
-
-Este proyecto se originó de un proyecto de curso mientras estudiaba en CESDE. Tenía la intención de crear una página tipo Airbnb con conexión a una API para realizar operaciones CRUD para reservas y crear reservas a través de formularios. Esto fue desarrollado completamente en Angular con TypeScript para asegurar una mejor organización de componentes.
-
-## Tecnologías Utilizadas
-
-El proyecto ha sido desarrollado usando las siguientes tecnologías:
-
-- **Angular**: Un framework de desarrollo de aplicaciones web de código abierto basado en TypeScript. Angular permite crear aplicaciones de página única (SPA) de manera eficiente y escalable.
-- **HTML**: Utilizado para definir la estructura y contenido de las páginas web.
-- **CSS**: Utilizado para dar estilo y diseño a las páginas web.
-- **TypeScript**: Un lenguaje de programación basado en JavaScript que añade características adicionales, como tipado estático, proporcionando mayor robustez al código.
-
-## Estructura del Repositorio
-
-El repositorio está organizado de la siguiente manera:
-
-- `app/`: Esta carpeta contiene el código fuente de la aplicación Angular.
-- `docs/`: Aquí encontrarás documentación adicional relacionada con el proyecto.
-- `tests/`: Esta carpeta contiene los archivos de prueba para el código.
-- `README.md`: Este archivo, que estás leyendo actualmente, proporciona información general sobre el repositorio.
-
-#### Puedes encontrar el proyecto en los siguientes enlaces
-
-- Sitio web del proyecto: https://hotelesquimbaya.vercel.app/
-- Repositorio del proyecto: https://github.com/amonsalv/hotelesquimbaya

--- a/src/content/work/quinbaya-hotels.md
+++ b/src/content/work/quinbaya-hotels.md
@@ -10,39 +10,29 @@ tags:
   - Dev
   - Angular
   - TypeScript
+liveUrl: https://hotelesquimbaya.vercel.app/
+githubUrl: https://github.com/amonsalv/hotelesquimbaya
+problem: |
+  A course project at CESDE: build an Airbnb-style booking experience — search, reserve, and manage hotel rooms — backed by a real API for CRUD operations on reservations. Built entirely in Angular with TypeScript for better component organization, with guidance from my instructor Juan José Gallego.
+solution:
+  columns:
+    - title: What it does
+      items:
+        - Browse cabins and rooms across different Quimbaya properties
+        - View availability and detailed room information
+        - Create a reservation through a validated booking form
+        - Manage or cancel existing reservations via the API
+techStack:
+  - category: Frontend
+    items:
+      - Angular
+      - TypeScript
+      - HTML
+      - CSS
+outcome:
+  steps:
+    - User browses available cabins and rooms
+    - User reviews room details and availability
+    - User submits a reservation through a validated form
+    - Reservation is created via a CRUD call to the API and can be managed later
 ---
-
-
-> I want to thank my teacher Juan Jose Gallego, for helping us to create this project, his patience to teach and his knowledge.
-
-## Intention of the Project
-
-This project originated from a course project while studying at CESDE. I intended to create an Airbnb-type page with a connection to an API to perform CRUD operations for reservations and to create reservations through forms. This was entirely developed in Angular with TypeScript to ensure better organization of components.
-
-
-## Technologies Used
-
-The project has been developed using the following technologies:
-
-- **Angular**: An open source web application development framework based on TypeScript. Angular allows creating single page applications (SPA) in an efficient and scalable way.
-- **HTML**: Used to define the structure and content of web pages.
-- **CSS**: Used to style and design web pages.
-- **TypeScript**: A programming language based on JavaScript that adds additional features, such as static typing, providing greater robustness to the code.
-
-## Repository Structure
-
-The repository is organized as follows:
-
-- `app/`: This folder contains the source code of the Angular application.
-- `docs/`: Here you will find additional documentation related to the project.
-- `tests/`: This folder contains the test files for the code.
-- `README.md`: This file, which you are currently reading, provides general information about the repository.
-
-
-#### You can find the project at the following links
-
-- Project website: https://hotelesquimbaya.vercel.app/
-- Project repository: https://github.com/amonsalv/hotelesquimbaya
-
-
-

--- a/src/content/work/telas3b-es.md
+++ b/src/content/work/telas3b-es.md
@@ -12,82 +12,71 @@ tags:
   - TypeScript
   - MySQL
   - AWS
+problem: |
+  Telas 3B es una aplicación web empresarial desarrollada para optimizar y digitalizar el proceso de producción de una manufactura textil — realizada como parte de mi Tecnología en Análisis y Desarrollo de Software en el SENA. Antes de este sistema, el seguimiento de órdenes se hacía manualmente; hoy todo el flujo, desde que un cliente hace un pedido hasta que sale despachado, queda registrado y visible en tiempo real.
+solution:
+  intro: |
+    Dos dashboards, una sola fuente de verdad — el estado de la orden se actualiza en tiempo real a medida que el trabajo avanza en planta.
+  columns:
+    - title: Para Administradores
+      items:
+        - "Crean órdenes de producción y las asignan por etapas: Corte → Confección → Estampado → Despacho"
+        - Gestionan la base de datos de clientes con historial completo de pedidos
+        - Controlan el inventario de telas e insumos con alertas de stock mínimo
+        - Monitorean métricas del negocio desde un dashboard centralizado
+        - Generan reportes de producción con tiempos estimados vs. reales
+    - title: Para Operarios
+      items:
+        - Visualizan sus tareas asignadas por etapa de producción
+        - Registran el inicio y fin de cada trabajo
+        - Actualizan el progreso en tiempo real
+        - Ven el estado actual de las órdenes en las que trabajan
+techStack:
+  - category: Frontend
+    items:
+      - React 18
+      - TypeScript
+      - Vite
+      - Zustand
+      - React Router DOM
+      - CSS Modules
+  - category: Backend
+    items:
+      - Java 17
+      - Spring Boot 3
+      - JPA / Hibernate
+      - Maven
+  - category: Base de Datos
+    items:
+      - MySQL 8
+      - AWS RDS
+      - Modelo relacional de 6 tablas
+  - category: Auth & Infra
+    items:
+      - Firebase Authentication
+      - JWT
+      - AWS EC2
+      - pnpm
+      - ESLint
+      - Husky
+architecture:
+  code: |
+    React SPA (Vite)  ──→  Spring Boot REST API  ──→  MySQL (RDS)
+       Firebase Auth  ──→  Validación de token JWT
+  description: |
+    Separación clara entre el frontend SPA y un backend API stateless; control de acceso basado en roles (admin/operario) protegiendo rutas tanto en frontend como en backend; ORM con Hibernate/JPA; estado global reactivo con Zustand para sincronizar datos entre vistas sin prop-drilling; patrón Repository en el backend para desacoplar la lógica de negocio del acceso a datos.
+outcome:
+  highlights:
+    - "Diseño de base de datos: modelado relacional completo con 6 tablas (usuarios, clientes, órdenes, etapas de producción, tareas, inventario)"
+    - "API REST completa: endpoints CRUD para órdenes, tareas, clientes e inventario con Spring Boot"
+    - "Frontend full-featured: dashboard dual, formularios con validación, tablas paginadas, filtros avanzados"
+    - "Sistema de autenticación: integración Firebase con el backend mediante interceptores Axios"
+    - "Despliegue en AWS: backend en EC2, base de datos en RDS, frontend optimizado con Vite"
+  steps:
+    - El administrador crea una orden y asigna cantidad, tipo de tela y fechas.
+    - El sistema genera automáticamente las tareas por etapa — Corte, Confección, Estampado, Despacho.
+    - Los operarios ven sus tareas pendientes y registran inicio y fin de cada trabajo.
+    - "El estado de la orden se actualiza en tiempo real — pending → in-progress → completed."
+    - La orden se marca como finalizada cuando todas las etapas se completan.
+    - Se generan reportes de productividad y se controla el inventario utilizado automáticamente.
 ---
-
-## Descripción del Proyecto
-
-Telas 3B es una aplicación web empresarial desarrollada para optimizar y digitalizar el proceso de producción de una manufactura textil. Este proyecto fue realizado como parte de mi Tecnología en Análisis y Desarrollo de Software en el SENA. Antes de este sistema, el seguimiento de órdenes se hacía manualmente; hoy todo el flujo —desde que un cliente hace un pedido hasta que sale despachado— queda registrado y visible en tiempo real.
-
-## ¿Qué hace el sistema?
-
-### Para Administradores
-- Crean órdenes de producción y las asignan por etapas: **Corte → Confección → Estampado → Despacho**
-- Gestionan la base de datos de clientes con historial completo de pedidos
-- Controlan el inventario de telas e insumos con alertas de stock mínimo
-- Monitorean métricas del negocio desde un dashboard centralizado
-- Generan reportes de producción con tiempos estimados vs. reales
-
-### Para Operarios
-- Visualizan sus tareas asignadas por etapa de producción
-- Registran el inicio y fin de cada trabajo
-- Actualizan el progreso en tiempo real
-- Ven el estado actual de las órdenes en las que trabajan
-
-## Stack Tecnológico
-
-### Frontend
-- **React 18** · **TypeScript** · **Vite** · **Zustand** · **React Router DOM**
-- **CSS Modules** con variables CSS personalizadas
-
-### Backend
-- **Java 17** · **Spring Boot 3** · **JPA/Hibernate** · **Maven**
-- Arquitectura REST API stateless
-
-### Base de Datos
-- **MySQL 8** alojada en AWS RDS
-- Modelado relacional con 6 tablas principales
-
-### Autenticación
-- **Firebase Authentication** (OAuth2 / JWT)
-- Validación de tokens en backend
-- Control de acceso basado en roles
-
-### Infraestructura
-- **AWS EC2** para el backend
-- **AWS RDS** para la base de datos
-- **pnpm** · **ESLint** · **Prettier** · **Husky** · **GitHub**
-
-## Arquitectura
-
-Arquitectura en capas con patrón MVC y comunicación desacoplada vía REST API:
-
-```
-React SPA (Vite)  ──→  Spring Boot REST API  ──→  MySQL (RDS)
-   Firebase Auth  ──→  Token JWT validation
-```
-
-**Características arquitectónicas:**
-
-- Separación clara entre frontend SPA y backend API stateless
-- Control de acceso basado en roles (admin / operator) protegiendo rutas tanto en frontend como en backend
-- ORM con Hibernate/JPA para mapeo objeto-relacional sin SQL manual
-- Estado global reactivo con Zustand para sincronizar datos entre vistas sin prop-drilling
-- Patrón Repository en el backend para desacoplar la lógica de negocio del acceso a datos
-
-## Lo que construí
-
-- **Diseño de base de datos**: Modelado completo de la base de datos relacional con 6 tablas (usuarios, clientes, órdenes, etapas de producción, tareas, inventario)
-- **API REST completa**: Endpoints para CRUD de órdenes, tareas, clientes e inventario con Spring Boot
-- **Frontend full-featured**: Dashboard dual (admin/operario), formularios con validación, tablas paginadas y filtros avanzados
-- **Sistema de autenticación**: Integración Firebase con backend mediante interceptores Axios
-- **Flujo de producción automatizado**: Las órdenes avanzan automáticamente de `pending` → `in-progress` → `completed` según el operario completa sus etapas
-- **Despliegue en AWS**: Backend en EC2, base de datos en RDS, frontend optimizado con Vite
-
-## Flujo de Trabajo
-
-1. El administrador crea una orden y asigna cantidad, tipo de tela y fechas
-2. El sistema genera automáticamente las tareas por etapa (Corte, Confección, Estampado, Despacho)
-3. Los operarios ven sus tareas pendientes y registran inicio/fin
-4. El sistema actualiza el estado de la orden en tiempo real
-5. Cuando todas las etapas se completan, la orden se marca como finalizada
-6. Se generan reportes de productividad y se controla el inventario utilizado

--- a/src/content/work/telas3b.md
+++ b/src/content/work/telas3b.md
@@ -12,82 +12,71 @@ tags:
   - TypeScript
   - MySQL
   - AWS
+problem: |
+  Telas 3B is an enterprise web application developed to optimize and digitalize the production process of a textile manufacturing company — completed as part of my Technology degree in Software Analysis and Development at SENA. Before this system, order tracking was done manually; today, the entire flow, from when a customer places an order to when it's dispatched, is recorded and visible in real time.
+solution:
+  intro: |
+    Two dashboards, one shared source of truth — order status updates in real time as work moves through the floor.
+  columns:
+    - title: For Administrators
+      items:
+        - "Create production orders and assign them by stages: Cutting → Sewing → Printing → Dispatch"
+        - Manage the customer database with complete order history
+        - Control fabric and supply inventory with minimum stock alerts
+        - Monitor business metrics from a centralized dashboard
+        - Generate production reports with estimated vs. actual times
+    - title: For Operators
+      items:
+        - View their assigned tasks by production stage
+        - Record the start and end of each job
+        - Update progress in real time
+        - See the current status of the orders they're working on
+techStack:
+  - category: Frontend
+    items:
+      - React 18
+      - TypeScript
+      - Vite
+      - Zustand
+      - React Router DOM
+      - CSS Modules
+  - category: Backend
+    items:
+      - Java 17
+      - Spring Boot 3
+      - JPA / Hibernate
+      - Maven
+  - category: Database
+    items:
+      - MySQL 8
+      - AWS RDS
+      - 6-table relational model
+  - category: Auth & Infra
+    items:
+      - Firebase Authentication
+      - JWT
+      - AWS EC2
+      - pnpm
+      - ESLint
+      - Husky
+architecture:
+  code: |
+    React SPA (Vite)  ──→  Spring Boot REST API  ──→  MySQL (RDS)
+       Firebase Auth  ──→  Token JWT validation
+  description: |
+    Clear separation between the SPA frontend and a stateless API backend; role-based access control (admin/operator) protecting routes on both frontend and backend; ORM with Hibernate/JPA; reactive global state with Zustand to sync data across views without prop-drilling; Repository pattern on the backend to decouple business logic from data access.
+outcome:
+  highlights:
+    - "Database design: complete relational modeling with 6 tables (users, customers, orders, production stages, tasks, inventory)"
+    - "Complete REST API: CRUD endpoints for orders, tasks, customers, and inventory with Spring Boot"
+    - "Full-featured frontend: dual dashboard, validated forms, paginated tables, advanced filters"
+    - "Authentication system: Firebase integration with the backend via Axios interceptors"
+    - "AWS deployment: backend on EC2, database on RDS, frontend optimized with Vite"
+  steps:
+    - Administrator creates an order and assigns quantity, fabric type, and dates.
+    - System auto-generates tasks by stage — Cutting, Sewing, Printing, Dispatch.
+    - Operators see pending tasks and record start and end times as they work.
+    - "Order status updates in real time — pending → in-progress → completed."
+    - Order is marked finished once every stage is complete.
+    - Productivity reports are generated and inventory usage is tracked automatically.
 ---
-
-## Project Description
-
-Telas 3B is an enterprise web application developed to optimize and digitalize the production process of a textile manufacturing company. This project was completed as part of my Technology degree in Software Analysis and Development at SENA. Before this system, order tracking was done manually; today, the entire flow—from when a customer places an order to when it's dispatched—is recorded and visible in real-time.
-
-## What does the system do?
-
-### For Administrators
-- Create production orders and assign them by stages: **Cutting → Sewing → Printing → Dispatch**
-- Manage the customer database with complete order history
-- Control fabric and supply inventory with minimum stock alerts
-- Monitor business metrics from a centralized dashboard
-- Generate production reports with estimated vs. actual times
-
-### For Operators
-- View their assigned tasks by production stage
-- Record the start and end of each job
-- Update progress in real-time
-- See the current status of the orders they're working on
-
-## Tech Stack
-
-### Frontend
-- **React 18** · **TypeScript** · **Vite** · **Zustand** · **React Router DOM**
-- **CSS Modules** with custom CSS variables
-
-### Backend
-- **Java 17** · **Spring Boot 3** · **JPA/Hibernate** · **Maven**
-- Stateless REST API architecture
-
-### Database
-- **MySQL 8** hosted on AWS RDS
-- Relational modeling with 6 main tables
-
-### Authentication
-- **Firebase Authentication** (OAuth2 / JWT)
-- Token validation on backend
-- Role-based access control
-
-### Infrastructure
-- **AWS EC2** for backend
-- **AWS RDS** for database
-- **pnpm** · **ESLint** · **Prettier** · **Husky** · **GitHub**
-
-## Architecture
-
-Layered architecture with MVC pattern and decoupled communication via REST API:
-
-```
-React SPA (Vite)  ──→  Spring Boot REST API  ──→  MySQL (RDS)
-   Firebase Auth  ──→  Token JWT validation
-```
-
-**Architectural features:**
-
-- Clear separation between SPA frontend and stateless API backend
-- Role-based access control (admin / operator) protecting routes on both frontend and backend
-- ORM with Hibernate/JPA for object-relational mapping without manual SQL
-- Reactive global state with Zustand to synchronize data between views without prop-drilling
-- Repository pattern on backend to decouple business logic from data access
-
-## What I built
-
-- **Database design**: Complete relational database modeling with 6 tables (users, customers, orders, production stages, tasks, inventory)
-- **Complete REST API**: Endpoints for CRUD operations on orders, tasks, customers, and inventory with Spring Boot
-- **Full-featured frontend**: Dual dashboard (admin/operator), forms with validation, paginated tables, and advanced filters
-- **Authentication system**: Firebase integration with backend using Axios interceptors
-- **Automated production flow**: Orders automatically advance from `pending` → `in-progress` → `completed` as operators complete their stages
-- **AWS deployment**: Backend on EC2, database on RDS, frontend optimized with Vite
-
-## Workflow
-
-1. Administrator creates an order and assigns quantity, fabric type, and dates
-2. System automatically generates tasks by stage (Cutting, Sewing, Printing, Dispatch)
-3. Operators see their pending tasks and record start/end times
-4. System updates order status in real-time
-5. When all stages are completed, the order is marked as finished
-6. Productivity reports are generated and inventory usage is tracked

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -1,211 +1,602 @@
 ---
-import { type CollectionEntry, getCollection, render } from 'astro:content';
+import { type CollectionEntry, getCollection } from 'astro:content';
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ContactCTA from '../../components/ContactCTA.astro';
-import Hero from '../../components/Hero.astro';
 import Icon from '../../components/Icon.astro';
 import Pill from '../../components/Pill.astro';
 
 interface Props {
 	entry: CollectionEntry<'work'>;
+	nextEntry: CollectionEntry<'work'> | null;
 }
 
 // This is a dynamic route that generates a page for every Markdown file in src/content/
 // Read more about dynamic routes and this `getStaticPaths` function in the Astro docs:
 // https://docs.astro.build/en/core-concepts/routing/#dynamic-routes
 export async function getStaticPaths() {
+	const isEsId = (id: string) => id.replace(/\.md$/, '').endsWith('-es');
 	const work = await getCollection('work');
-	return work.map((entry) => ({
-		params: { slug: entry.id },
-		props: { entry },
-	}));
+	return work.map((entry) => {
+		const isEs = isEsId(entry.id);
+		const localeEntries = work
+			.filter((e) => isEsId(e.id) === isEs)
+			.sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
+		const idx = localeEntries.findIndex((e) => e.id === entry.id);
+		const nextEntry = localeEntries.length > 1 ? localeEntries[(idx + 1) % localeEntries.length] : null;
+
+		return {
+			params: { slug: entry.id },
+			props: { entry, nextEntry },
+		};
+	});
 }
 
-const { entry } = Astro.props;const { Content } = await render(entry);
+const { entry, nextEntry } = Astro.props;
+const { data } = entry;
+const isEs = entry.id.replace(/\.md$/, '').endsWith('-es');
+
+const t = isEs
+	? {
+			eyebrow: 'Caso de estudio',
+			back: 'Volver a Work',
+			viewLive: 'Ver en vivo',
+			github: 'GitHub',
+			problem: 'El Problema',
+			solution: 'La Solución',
+			technology: 'Tecnología',
+			architecture: 'Arquitectura',
+			outcome: 'Resultado',
+			nextProject: 'Siguiente proyecto',
+			seeAllWork: 'Ver todo el trabajo',
+		}
+	: {
+			eyebrow: 'Case Study',
+			back: 'Back to Work',
+			viewLive: 'View live',
+			github: 'GitHub',
+			problem: 'The Problem',
+			solution: 'The Solution',
+			technology: 'Technology',
+			architecture: 'Architecture',
+			outcome: 'Outcome',
+			nextProject: 'Next project',
+			seeAllWork: 'See all work',
+		};
+
+const accentColors = ['var(--chroma-ocean)', 'var(--chroma-nature)', 'var(--chroma-sunny)', 'var(--chroma-purple)'];
+
+function tagCategory(tag: string) {
+	const lower = tag.toLowerCase();
+	if (lower.includes('design') || lower.includes('ui') || lower.includes('ux') || lower.includes('diseño')) return 'design';
+	if (lower.includes('angular') || lower.includes('react') || lower.includes('astro') || lower.includes('express') || lower.includes('js')) return 'stack';
+	return 'dev';
+}
+
+function iconForCategory(category: string) {
+	const c = category.toLowerCase();
+	if (c.includes('front')) return 'code';
+	if (c.includes('back') || c.includes('data') || c.includes('base')) return 'database';
+	if (c.includes('test')) return 'wrench';
+	if (c.includes('auth') || c.includes('infra')) return 'cloud';
+	return 'gear';
+}
 ---
 
-<BaseLayout title={entry.data.title} description={entry.data.description}>
-	<div class="stack gap-20">
-		<div class="stack gap-15">
-			<header class="project-header wrapper">
-				<a class="back-link" href="/work/" aria-label="Back to Work">
-					<Icon icon="arrow-left" />
-					<span data-translate="work.backLink">Work</span>
-				</a>
-
-				<div class="hero-shell">
-					<div class="hero-main stack gap-4">
-						<Hero title={entry.data.title} align="start" />
-						<p class="description">{entry.data.description}</p>
-						<div class="tags">
-							{entry.data.tags.map((t) => {
-								let cat = 'dev';
-								if (t.toLowerCase().includes('design') || t.toLowerCase().includes('ui') || t.toLowerCase().includes('ux')) cat = 'design';
-								else if (t.toLowerCase().includes('angular') || t.toLowerCase().includes('react') || t.toLowerCase().includes('astro') || t.toLowerCase().includes('express') || t.toLowerCase().includes('js')) cat = 'stack';
-								
-								return <Pill category={cat as any}>{t}</Pill>;
-							})}
-						</div>
+<BaseLayout title={data.title} description={data.description}>
+	<main class="pd-page">
+		<!-- ===================== HERO ===================== -->
+		<section class="pd-hero wrapper">
+			<a class="pd-back" href="/work/">
+				<Icon icon="arrow-left" size="1em" />
+				{t.back}
+			</a>
+			<div class="pd-hero-grid">
+				<div>
+					<span class="pd-eyebrow">{t.eyebrow}</span>
+					<h1 class="pd-title">{data.title}</h1>
+					<p class="pd-lede">{data.description}</p>
+					<div class="pd-tags">
+						{data.tags.map((tag) => <Pill category={tagCategory(tag)}>{tag}</Pill>)}
 					</div>
-					{entry.data.img && (
-						<div class="hero-media">
-							<img src={entry.data.img} alt={entry.data.img_alt || ''} loading="eager" decoding="async" />
+					{(data.liveUrl || data.githubUrl) && (
+						<div class="pd-links">
+							{data.liveUrl && (
+								<a class="pd-btn-primary" href={data.liveUrl} target="_blank" rel="noopener noreferrer">
+									{t.viewLive}
+								</a>
+							)}
+							{data.githubUrl && (
+								<a class="pd-btn-ghost" href={data.githubUrl} target="_blank" rel="noopener noreferrer">
+									{t.github}
+								</a>
+							)}
 						</div>
 					)}
 				</div>
-			</header>
+				<div class="pd-hero-visual">
+					<img src={data.img} alt={data.img_alt || ''} loading="eager" decoding="async" />
+				</div>
+			</div>
+		</section>
 
-			<main class="wrapper project-content">
-				<article class="content prose-card">
-					<Content />
-				</article>
-			</main>
-		</div>
+		<!-- ===================== PROBLEM ===================== -->
+		<section class="pd-section bg-mist">
+			<div class="wrapper">
+				<div class="pd-head reveal">
+					<h2 class="section-title">{t.problem}</h2>
+					<p>{data.problem}</p>
+				</div>
+			</div>
+		</section>
+
+		<!-- ===================== SOLUTION ===================== -->
+		<section class="pd-section">
+			<div class="wrapper">
+				<div class="pd-head reveal">
+					<h2 class="section-title">{t.solution}</h2>
+					{data.solution.intro && <p>{data.solution.intro}</p>}
+				</div>
+				<div class:list={['pd-cols', 'reveal', { 'pd-cols-single': data.solution.columns.length === 1 }]} data-stagger>
+					{data.solution.columns.map((col, i) => (
+						<article class="pd-col" style={`--pc:${accentColors[i % accentColors.length]}`}>
+							<h3>{col.title}</h3>
+							<ul>
+								{col.items.map((item) => <li>{item}</li>)}
+							</ul>
+						</article>
+					))}
+				</div>
+			</div>
+		</section>
+
+		<!-- ===================== TECHNOLOGY ===================== -->
+		<section class="pd-section bg-mist">
+			<div class="wrapper">
+				<div class="pd-head reveal">
+					<h2 class="section-title">{t.technology}</h2>
+				</div>
+				<div class="pd-stack-grid reveal" data-stagger>
+					{data.techStack.map((stack, i) => (
+						<article class="tool-card" style={`--tc:${accentColors[i % accentColors.length]}`}>
+							<div class="tool-card-header">
+								<Icon icon={iconForCategory(stack.category)} size="1.3em" />
+								<h3>{stack.category}</h3>
+							</div>
+							<div class="chips">
+								{stack.items.map((item) => <span>{item}</span>)}
+							</div>
+						</article>
+					))}
+				</div>
+
+				{data.architecture && (
+					<div class="pd-architecture reveal">
+						<p class="pd-architecture-label">{t.architecture}</p>
+						<div class="code-card">
+							<pre>{data.architecture.code}</pre>
+						</div>
+						<p class="pd-architecture-desc">{data.architecture.description}</p>
+					</div>
+				)}
+			</div>
+		</section>
+
+		<!-- ===================== OUTCOME ===================== -->
+		<section class="pd-section">
+			<div class="wrapper">
+				<div class="pd-head reveal">
+					<h2 class="section-title">{t.outcome}</h2>
+				</div>
+				{data.outcome.highlights && (
+					<ul class="pd-highlights reveal">
+						{data.outcome.highlights.map((h) => <li>{h}</li>)}
+					</ul>
+				)}
+				<div class="pd-steps reveal" data-stagger>
+					{data.outcome.steps.map((step) => (
+						<div class="pd-step">
+							<span class="num"></span>
+							<p>{step}</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</section>
+
+		<!-- ===================== NEXT PROJECT ===================== -->
+		{nextEntry && (
+			<section class="pd-section">
+				<div class="wrapper">
+					<div class="pd-next reveal">
+						<span class="pd-next-eyebrow">{t.nextProject}</span>
+						<h3><a href={`/work/${nextEntry.id}`}>{nextEntry.data.title} →</a></h3>
+						<a class="pd-btn-primary" href="/work/">{t.seeAllWork}</a>
+					</div>
+				</div>
+			</section>
+		)}
+
 		<div class="wrapper">
 			<ContactCTA />
 		</div>
-	</div>
+	</main>
 </BaseLayout>
 
 <style>
-	.project-header {
+	/* ── Hero ── */
+	.pd-hero {
 		padding-top: 2.5rem;
-		padding-bottom: 2.5rem;
+		padding-bottom: 3rem;
 	}
 
-	.back-link {
+	.pd-back {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
-		margin-bottom: 1.25rem;
+		margin-bottom: 1.5rem;
 		font-weight: 700;
+		font-size: 0.9rem;
+		color: var(--on-surface-variant);
+		transition: color var(--theme-transition);
+	}
+
+	.pd-back:hover,
+	.pd-back:focus {
 		color: var(--primary);
 	}
 
-	.hero-shell {
+	.pd-hero-grid {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 1.25rem;
-		padding: 1.2rem;
-		border-radius: var(--radius-xl);
-		background: var(--surface-container-low);
-		border: 1px solid color-mix(in srgb, var(--outline-variant) 35%, transparent);
-		box-shadow: var(--shadow-sm);
+		gap: 2rem;
+		align-items: center;
 	}
 
-	.hero-main {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
+	.pd-eyebrow {
+		display: inline-block;
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--chroma-purple);
+		margin-bottom: 0.75rem;
 	}
 
-	.tags {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
+	.pd-title {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: clamp(2.5rem, 6vw, 4rem);
+		line-height: 0.98;
+		letter-spacing: -0.03em;
+		color: var(--on-surface);
+		margin-bottom: 1.25rem;
 	}
 
-	.hero-media {
-		border-radius: calc(var(--radius-xl) - 0.3rem);
-		overflow: hidden;
-		min-height: 16rem;
-	}
-
-	.hero-media img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
-	.description {
+	.pd-lede {
 		font-size: var(--text-lg);
 		max-width: 52ch;
 		color: var(--on-surface-variant);
+		line-height: 1.6;
+		margin-bottom: 1.5rem;
 	}
 
-	.project-content {
-		padding-top: 0.25rem;
+	.pd-tags {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-bottom: 1.5rem;
 	}
 
-	.content {
-		max-width: 65ch;
-		margin-inline: auto;
+	.pd-links {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
 	}
 
-	.prose-card {
-		padding: 1.4rem;
+	.pd-btn-primary,
+	.pd-btn-ghost {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.6rem 1.4rem;
+		border-radius: 999px;
+		font-weight: 700;
+		font-size: 0.9rem;
+		text-decoration: none;
+		transition: background 0.2s, color 0.2s, transform 0.2s;
+	}
+
+	.pd-btn-primary {
+		background: var(--chroma-ocean);
+		color: #fff;
+	}
+
+	.pd-btn-primary:hover {
+		background: var(--chroma-ocean-strong);
+		transform: translateY(-1px);
+	}
+
+	.pd-btn-ghost {
+		background: transparent;
+		color: var(--on-surface);
+		border: 1.5px solid var(--outline-variant);
+	}
+
+	.pd-btn-ghost:hover {
+		border-color: var(--on-surface);
+		transform: translateY(-1px);
+	}
+
+	.pd-hero-visual {
 		border-radius: var(--radius-xl);
+		overflow: hidden;
+		min-height: 16rem;
+		box-shadow: var(--shadow-md);
+	}
+
+	.pd-hero-visual img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	/* ── Sections ── */
+	.pd-section {
+		padding-block: 4rem;
+	}
+
+	.pd-head {
+		max-width: 680px;
+		margin-bottom: 2.5rem;
+	}
+
+	.pd-head p {
+		font-size: 1.05rem;
+		color: var(--on-surface-variant);
+		line-height: 1.7;
+		max-width: 68ch;
+	}
+
+	/* ── Solution columns ── */
+	.pd-cols {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1.5rem;
+	}
+
+	.pd-cols-single {
+		max-width: 620px;
+	}
+
+	.pd-col {
 		background: var(--surface-container-lowest);
-		border: 1px solid color-mix(in srgb, var(--outline-variant) 28%, transparent);
+		border-radius: var(--radius-lg);
+		padding: 1.75rem;
+		border-top: 3px solid var(--pc);
 		box-shadow: var(--shadow-sm);
 	}
 
-	.content > :global(* + *) {
-		margin-top: 1.15rem;
-	}
-
-	.content :global(h1),
-	.content :global(h2),
-	.content :global(h3),
-	.content :global(h4),
-	.content :global(h5) {
-		margin: 1.5rem 0;
-	}
-
-	.content :global(img) {
-		border-radius: 1.5rem;
-		box-shadow: var(--shadow-md);
-		background: var(--gradient-subtle);
-		border: 1px solid color-mix(in srgb, var(--outline-variant) 35%, transparent);
-	}
-
-	.content :global(blockquote) {
+	.pd-col h3 {
 		font-size: var(--text-lg);
-		font-family: 'Newsreader', Georgia, serif;
-		font-weight: 500;
-		line-height: 1.25;
-		font-style: italic;
-		padding-inline-start: 1.5rem;
-		border-inline-start: 0.25rem solid var(--primary);
-		color: var(--gray-0);
+		font-weight: 700;
+		margin-bottom: 1rem;
+		color: var(--pc);
 	}
 
-	.back-link,
-	.content :global(a) {
-		text-decoration: 1px solid underline transparent;
-		text-underline-offset: 0.25em;
-		transition: text-decoration-color var(--theme-transition);
+	.pd-col ul {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
 	}
 
-	.back-link:hover,
-	.back-link:focus,
-	.content :global(a:hover),
-	.content :global(a:focus) {
-		text-decoration-color: currentColor;
+	.pd-col li {
+		font-size: 0.97rem;
+		line-height: 1.55;
+		color: var(--on-surface-variant);
+		padding-left: 1rem;
+		position: relative;
+	}
+
+	.pd-col li::before {
+		content: '—';
+		position: absolute;
+		left: 0;
+		color: var(--pc);
+	}
+
+	/* ── Tech stack ── */
+	.pd-stack-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1.5rem;
+		margin-bottom: 2.5rem;
+	}
+
+	.tool-card {
+		background: var(--surface-container-lowest);
+		border-radius: var(--radius-lg);
+		padding: 1.75rem;
+		box-shadow: var(--shadow-sm);
+	}
+
+	.tool-card-header {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		margin-bottom: 1.25rem;
+		color: var(--tc);
+		font-weight: 800;
+	}
+
+	.tool-card-header h3 {
+		font-size: 1.05rem;
+		font-weight: 800;
+		color: var(--tc);
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+	}
+
+	.chips span {
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--tc);
+		background: color-mix(in srgb, var(--tc) 12%, var(--surface-container-lowest));
+		padding: 0.4rem 0.85rem;
+		border-radius: 999px;
+	}
+
+	/* ── Architecture ── */
+	.pd-architecture-label {
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--on-surface-variant);
+		margin-bottom: 1rem;
+	}
+
+	.code-card {
+		position: relative;
+		width: 100%;
+		max-width: 640px;
+		border-radius: var(--radius-lg);
+		background: linear-gradient(135deg, var(--chroma-ocean), var(--chroma-purple));
+		padding: 1.75rem;
+		overflow-x: auto;
+	}
+
+	.code-card pre {
+		font-family: var(--font-mono);
+		font-size: 13px;
+		line-height: 1.7;
+		color: rgba(255, 255, 255, 0.85);
+		white-space: pre;
+	}
+
+	.pd-architecture-desc {
+		max-width: 70ch;
+		color: var(--on-surface-variant);
+		margin-top: 1.25rem;
+		line-height: 1.65;
+		font-size: 0.97rem;
+	}
+
+	/* ── Outcome ── */
+	.pd-highlights {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		margin-bottom: 2rem;
+		max-width: 760px;
+	}
+
+	.pd-highlights li {
+		font-size: 0.97rem;
+		line-height: 1.55;
+		color: var(--on-surface-variant);
+		padding-left: 1rem;
+		position: relative;
+	}
+
+	.pd-highlights li::before {
+		content: '—';
+		position: absolute;
+		left: 0;
+		color: var(--primary);
+	}
+
+	.pd-steps {
+		counter-reset: step;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		max-width: 760px;
+	}
+
+	.pd-step {
+		display: flex;
+		gap: 1.25rem;
+		align-items: flex-start;
+	}
+
+	.pd-step .num {
+		counter-increment: step;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.35rem;
+		color: var(--primary);
+		width: 2.75rem;
+		height: 2.75rem;
+		flex: none;
+		border-radius: 50%;
+		background: color-mix(in srgb, var(--primary) 12%, transparent);
+		display: grid;
+		place-items: center;
+	}
+
+	.pd-step .num::before {
+		content: counter(step);
+	}
+
+	.pd-step p {
+		font-size: 1rem;
+		line-height: 1.6;
+		color: var(--on-surface-variant);
+		padding-top: 0.5rem;
+	}
+
+	/* ── Next project ── */
+	.pd-next {
+		background: #0f121d;
+		color: #fff;
+		border-radius: var(--radius-xl);
+		padding: 3.5rem 2rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.pd-next-eyebrow {
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: rgba(255, 255, 255, 0.5);
+	}
+
+	.pd-next h3 {
+		font-family: var(--font-display);
+		font-weight: 600;
+		font-size: 2rem;
+	}
+
+	.pd-next h3 a {
+		color: #fff;
 	}
 
 	@media (min-width: 50em) {
-		.project-header {
-			padding-top: 3rem;
+		.pd-hero {
+			padding-top: 3.5rem;
 		}
 
-		.hero-shell {
-			grid-template-columns: 1.1fr 1fr;
-			gap: 1.8rem;
-			padding: 1.4rem;
+		.pd-hero-grid {
+			grid-template-columns: 1.3fr 1fr;
+			gap: 3rem;
 		}
 
-		.prose-card {
-			padding: 2rem;
+		.pd-cols:not(.pd-cols-single) {
+			grid-template-columns: 1fr 1fr;
 		}
 
-		.content :global(blockquote) {
-			font-size: var(--text-2xl);
+		.pd-stack-grid {
+			grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 		}
 	}
 </style>
-
-
-
-


### PR DESCRIPTION
## Summary
- Port the `.pd-*` case-study design (Hero, Problem, Solution, Technology, Outcome, Next project) into `/work/[...slug].astro`, replacing the flat markdown prose dump with sectioned, structured layout matching the Home/About redesign.
- Restructure all 5 projects' content (EN + ES) into structured frontmatter (`problem`, `solution`, `techStack`, `architecture`, `outcome`) instead of freeform markdown body.
- Add optional `liveUrl`/`githubUrl` frontmatter fields — hero buttons render only when set (omitted for the two private repos, Telas 3B and Ordenary).
- Add real "Next project" navigation, same-locale, wrapping.

## Test plan
- [x] `npm run build` (astro check + build) passes with 0 errors across all 10 content files
- [x] Verified all 5 projects (EN + ES) render correctly in the browser: hero, problem, solution columns, tech stack, architecture (where present), outcome steps, next-project link
- [x] Checked responsive collapse at mobile (375px) and desktop (1440px) widths
- [x] Confirmed live/GitHub buttons only appear where frontmatter data is set