### PR TITLE
Scale home Work section grid past 3 projects

### DIFF
--- a/.agents/skills/figma-design/REFERENCE.md
+++ b/.agents/skills/figma-design/REFERENCE.md
@@ -1,0 +1,184 @@
+# Figma Design System - Quick Reference
+
+## Token Variables Quick Lookup
+
+### Colors
+```css
+--chroma-ocean: #1565C0 (dark mode --primary: #a9c7ff)
+--chroma-ocean-strong: #0D47A1
+--chroma-purple: #7B1FA2 (dark mode --secondary: #ffd27a)
+--chroma-nature: #00897B (dark mode --tertiary: #9fd4b4)
+--chroma-sunny: #FFD600 (dark mode --secondary: #ffd27a)
+
+--surface: #F3F1FC (dark: #100f1c)
+--surface-container-lowest: #ffffff (dark: #0a0917)
+--surface-container: #E3DCFA (dark: #1c1a2c)
+--surface-container-high: #d8d0f5 (dark: #222035)
+--on-surface: #1a1c1b (dark: #e5e3f5)
+--on-surface-variant: #464554 (dark: #c8c5db)
+```
+Dark mode overrides live under `:root.theme-dark` in `tokens.css` — some roles resolve to different literal hexes rather than a fixed dark variant of the same `--chroma-*` constant, so check the file directly for anything beyond a quick lookup.
+
+### Font Families
+```
+--font-script: Caveat (cursive)
+--font-display: Fraunces (serif)
+--font-body / --font-brand: Plus Jakarta Sans (sans-serif)
+--font-mono: JetBrains Mono (monospace)
+```
+
+### Spacing
+No `--space-*` token scale exists in this codebase. Spacing is handled by utility classes in `layout.css`: `.gap-2` (0.5rem), `.gap-3` (0.75rem), `.gap-4` (1rem), `.gap-8` (2rem), `.gap-10` (2.5rem), `.gap-15` (3.75rem), `.gap-20` (5rem), `.gap-30` (7.5rem), `.gap-48` (12rem).
+
+### Border Radius (tokenized, in `tokens.css`)
+```
+--radius-sm: 0.375rem
+--radius-md: 0.75rem
+--radius-lg: 1.5rem
+--radius-xl: 2rem
+--radius-full: 9999px
+```
+
+---
+
+## Workflow Quick Start
+
+### When Starting a New Component
+1. **Find Figma frame** → Copy link
+2. **Document spec** → Use template above
+3. **Check tokens** → All colors in `tokens.css`?
+4. **Create Astro file** → `src/components/ComponentName.astro`
+5. **Map properties** → Figma props → Astro props
+6. **Test states** → Default, hover, active, disabled
+7. **Dark mode** → Verify colors work in dark
+8. **Responsive** → Check 3 breakpoints (mobile, tablet, desktop)
+
+### When Updating Design Tokens
+1. **Identify change** → In Figma
+2. **Update `tokens.css`** → Add new variable or modify
+3. **Audit usage** → grep for old value in components
+4. **Update components** → Replace with new variable
+5. **Test dark mode** → Ensure contrast
+6. **Commit separately** → `style: update design tokens`
+
+### Before Deploying
+1. **Visual QA** → Screenshot Figma vs live site
+2. **Responsive check** → Mobile, tablet, desktop
+3. **Dark mode test** → All variants in both themes
+4. **Accessibility** → Run audit tool
+5. **Performance** → Check image sizes, CSS size
+6. **Commit message** → Clear description of changes
+
+---
+
+## Git Commit Messages for Design Work
+
+```bash
+# New component
+feat(components): add ProjectCard component
+
+# Design token updates
+style(tokens): update color variables for new palette
+
+# Component updates
+refactor(components): improve Hero component styling
+
+# CSS refactoring
+refactor(styles): reorganize component styles
+
+# Dark mode fixes
+fix(theme): improve dark mode color contrast
+```
+
+---
+
+## Status Badges
+
+| Status | Meaning | Action |
+|---|---|---|
+| 🟢 Done | Implemented & tested | Ready to ship |
+| 🟡 In Progress | Being developed | Review spec |
+| 🔵 Draft | Design only, not coded | Plan implementation |
+| 🔴 Blocked | Can't proceed | Resolve blocker |
+| ⚪ Deprecated | No longer used | Can be removed |
+
+---
+
+## Quick Commands
+
+```bash
+# Search for color usage
+grep -r "chroma-ocean" src/
+
+# Find all CSS variables
+grep -r "var(--" src/ | grep -o "var(--[^)]*)" | sort | uniq
+
+# Test responsive design
+# Browser dev tools: F12 → Ctrl+Shift+M
+
+# Generate color contrast report
+# https://webaim.org/resources/contrastchecker/
+
+# Optimize SVG assets
+# https://jakearchibald.github.io/svgomg/
+
+# Export from Figma: File → Export → Select frames
+```
+
+---
+
+## Component Checklist
+
+Before marking a component as ✅ Done:
+
+- [ ] Figma spec documented
+- [ ] All variants created
+- [ ] TypeScript props defined
+- [ ] CSS matches Figma design
+- [ ] Dark mode tested
+- [ ] Mobile responsive (< 640px)
+- [ ] Tablet responsive (640-1024px)
+- [ ] Desktop responsive (> 1024px)
+- [ ] ARIA labels added
+- [ ] Keyboard navigation works
+- [ ] Color contrast AA minimum
+- [ ] Component in component library
+- [ ] Used in at least one page
+- [ ] Git commit with proper message
+- [ ] No console warnings/errors
+- [ ] Storybook docs updated (if applicable)
+
+---
+
+## Troubleshooting
+
+### Component looks different than Figma
+→ Check if all design tokens are using CSS variables
+→ Verify font weights, sizes, and line heights match
+→ Screenshot side-by-side for comparison
+
+### Dark mode colors not working
+→ Verify `:root.theme-dark` selector exists
+→ Check color-mix() fallbacks
+→ Test with Firefox dark mode enabled
+
+### SVG icons not displaying
+→ Ensure `public/` path is used: `public/assets/icons/icon.svg`
+→ Check SVG dimensions in Figma export
+→ Verify `fill` and `stroke` properties are set
+
+### Responsive breakpoints not working
+→ Check media query breakpoints: 50em (800px for tablet), etc.
+→ Use `clamp()` for fluid sizing
+→ Test with browser dev tools viewport settings
+
+---
+
+## Links & Resources
+
+- **Figma Design File**: [Add your Figma link]
+- **Deployed Site**: https://ana-monsalve.netlify.app
+- **Repository**: https://github.com/amonsalv/Portfolio-Astro
+- **Design Tokens**: `src/styles/tokens.css`
+- **Component Lib**: `src/components/`
+- **Styles Folder**: `src/styles/`

--- a/.agents/skills/figma-design/SKILL.md
+++ b/.agents/skills/figma-design/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: figma-design
+description: |
+  **Design System & Figma Workflow** — Maintain synchronization between Figma designs and Astro codebase.
+  
+  Use when: 
+  - Syncing design tokens (colors, typography, spacing) from Figma to CSS variables
+  - Creating Astro components from Figma frames
+  - Documenting component specifications and design decisions
+  - Running visual QA checks before pushing to production
+  - Handoff process: Figma design → code implementation
+  - Exporting assets and maintaining design-to-code consistency
+---
+
+# Figma Design System Integration
+
+## Design Tokens Mapping
+
+### Color System
+**Location**: `src/styles/tokens.css` (light mode on `:root`, dark mode on `:root.theme-dark`)
+
+| Figma Variable | CSS Custom Property | Light | Dark | Usage |
+|---|---|---|---|---|
+| `chroma/ocean` | `--chroma-ocean` | `#1565C0` | `--primary: #a9c7ff` | Primary brand, CTAs, accents |
+| `chroma/purple` | `--chroma-purple` | `#7B1FA2` | `--tertiary`-adjacent, see `--secondary` dark | Secondary accent, highlights |
+| `chroma/nature` | `--chroma-nature` | `#00897B` | `--tertiary: #9fd4b4` | Tertiary accent, borders |
+| `chroma/sunny` | `--chroma-sunny` | `#FFD600` | `--secondary: #ffd27a` | Attention, decorative |
+| `surface/container-lowest` | `--surface-container-lowest` | `#ffffff` | `#0a0917` | Card backgrounds |
+| `surface/container` | `--surface-container` | `#E3DCFA` | `#1c1a2c` | Component backgrounds |
+| `on-surface` | `--on-surface` | `#1a1c1b` | `#e5e3f5` | Primary text |
+| `on-surface-variant` | `--on-surface-variant` | `#464554` | `#c8c5db` | Secondary text |
+
+Dark mode isn't a simple per-color override — several roles (`--primary`, `--secondary`, `--tertiary`) resolve to different literal hex values under `:root.theme-dark` rather than reusing the same `--chroma-*` constants. Read `tokens.css` directly for the authoritative value rather than trusting this table for anything beyond a quick lookup.
+
+### Typography
+**Location**: `src/styles/tokens.css`
+
+```css
+/* Font families */
+--font-script:   'Caveat', cursive;
+--font-display:  'Fraunces', Georgia, serif;
+--font-mono:     'JetBrains Mono', 'Fira Code', monospace;
+--font-body:     'Plus Jakarta Sans', system-ui, sans-serif;
+--font-brand:    'Plus Jakarta Sans', system-ui, sans-serif;
+
+/* Font scale (static rem, not clamp) */
+--text-sm:   0.875rem;
+--text-base: 1rem;
+--text-md:   1.125rem;
+--text-lg:   1.25rem;
+--text-xl:   1.625rem;
+--text-2xl:  2.125rem;
+--text-3xl:  2.625rem;
+--text-4xl:  3.5rem;
+--text-5xl:  4.5rem;
+```
+
+### Spacing & Layout
+**Location**: `src/styles/layout.css`
+
+There is no `--space-*` token scale in this codebase — spacing is done via utility classes (`.gap-2` = 0.5rem, `.gap-4` = 1rem, `.gap-8` = 2rem, up to `.gap-48` = 12rem) rather than CSS custom properties. Border radius and easing *are* tokenized, in `tokens.css`:
+
+```css
+/* Border radius */
+--radius-sm:   0.375rem;
+--radius-md:   0.75rem;
+--radius-lg:   1.5rem;
+--radius-xl:   2rem;
+--radius-full: 9999px;
+
+/* Transitions */
+--theme-transition: 0.2s ease-in-out;
+--ease-expressive:  cubic-bezier(0.4, 0, 0.2, 1);
+```
+
+---
+
+## Component Specification Template
+
+Use this template when creating Astro components from Figma frames:
+
+```
+## ComponentName
+
+**Figma Frame**: [Link to frame in Figma]
+**Status**: [Draft | In Progress | Ready | Done]
+**Last Updated**: [YYYY-MM-DD]
+
+### Variants
+- [ ] Default state
+- [ ] Hover state
+- [ ] Active state
+- [ ] Disabled state
+- [ ] Dark mode
+
+### Responsive Breakpoints
+- Mobile: < 640px
+- Tablet: 640px - 1024px
+- Desktop: > 1024px
+
+### Accessibility
+- [ ] Semantic HTML
+- [ ] ARIA labels where needed
+- [ ] Color contrast tested
+- [ ] Keyboard navigation
+
+### CSS Classes
+- Primary: `.component-name`
+- Modifier: `.component-name--modifier`
+- State: `.component-name.active`
+
+### Implementation Notes
+- Any special handling or dependencies
+```
+
+---
+
+## Figma to Code Export Checklist
+
+### 1. Asset Export (Before Development)
+- [ ] Export all icon assets to `public/assets/icons/`
+- [ ] Export all image assets to `public/assets/images/`
+- [ ] Ensure SVGs are optimized
+- [ ] Document asset naming convention
+
+### 2. Design Token Verification
+- [ ] All colors mapped to CSS variables
+- [ ] Typography scales match design
+- [ ] Spacing values consistent
+- [ ] Update `tokens.css` if new tokens added
+
+### 3. Component Audit
+- [ ] Verify all Figma components have Astro counterparts
+- [ ] Check variant coverage (default, hover, active, disabled)
+- [ ] Test dark mode styling
+- [ ] Validate responsive behavior
+
+### 4. Quality Assurance
+- [ ] Visual regression test (compare Figma vs deployed)
+- [ ] Mobile responsiveness check
+- [ ] Cross-browser testing
+- [ ] Accessibility audit
+
+---
+
+## Current Design System Spec
+
+### Project: Portfolio-Astro
+
+**Design Language**: Warm Editorial Minimalism
+**Primary Color**: `chroma-ocean` (#1565C0 light → `--primary: #a9c7ff` dark)
+**Secondary Color**: `chroma-purple` (#7B1FA2)
+**Accent Color**: `chroma-nature` (#00897B light → `--tertiary: #9fd4b4` dark)
+
+**Key Characteristics**:
+- Bold typography with clear hierarchy
+- Generous whitespace
+- Soft shadow system
+- Smooth micro-interactions
+- Dark mode support
+
+---
+
+## Workflow: Figma → Astro
+
+### Phase 1: Design Validation
+1. Figma file updated with new components/variants
+2. Review in Figma - check spacing, colors, typography
+3. Document design decisions in component specs
+
+### Phase 2: Token Sync
+1. Extract new tokens from Figma
+2. Update `src/styles/tokens.css`
+3. Verify all CSS variables are defined
+
+### Phase 3: Component Implementation
+1. Create Astro component from Figma frame
+2. Map Figma properties to CSS classes
+3. Implement all variants and states
+4. Add TypeScript props for reusability
+
+### Phase 4: Integration Testing
+1. Test component in context on pages
+2. Verify dark mode
+3. Test responsive breakpoints
+4. Check accessibility
+
+### Phase 5: Visual QA & Deployment
+1. Screenshots comparison: Figma vs Astro
+2. Performance check
+3. Final accessibility audit
+4. Commit with proper message
+
+---
+
+## Common Component Patterns
+
+### Hero Section Pattern
+```astro
+---
+// Props from Figma spec
+interface Props {
+  title: string;
+  subtitle: string;
+  ctaText: string;
+  ctaHref: string;
+  theme?: 'light' | 'dark';
+}
+---
+
+<section class="hero" class:list={{'theme-dark': theme === 'dark'}}>
+  <h1 class="hero-title">{title}</h1>
+  <p class="hero-subtitle">{subtitle}</p>
+  <a href={ctaHref} class="hero-cta">{ctaText}</a>
+</section>
+```
+
+### Card Component Pattern
+```astro
+---
+interface Props {
+  title: string;
+  description: string;
+  tags?: string[];
+  image?: string;
+  variant?: 'default' | 'featured' | 'minimal';
+}
+---
+
+<article class="card" class:list={`card--${variant}`}>
+  {image && <img src={image} alt="" class="card-image" />}
+  <div class="card-content">
+    <h3 class="card-title">{title}</h3>
+    <p class="card-desc">{description}</p>
+    {tags && <div class="card-tags">{tags.map(tag => <span>{tag}</span>)}</div>}
+  </div>
+</article>
+```
+
+---
+
+## Naming Conventions
+
+### CSS Classes
+- Use kebab-case: `.component-name`
+- Modifiers: `.component-name--modifier`
+- States: `.component-name.is-active`
+- Utility prefixes: `.stack`, `.wrapper`, `.reveal`
+
+### Figma Component Names
+- Prefix with component type: `Button/Primary`, `Card/Featured`
+- Use forward slashes for hierarchy
+- Variant names: `[Default]`, `[Hover]`, `[Disabled]`
+
+### Astro Component Names
+- PascalCase: `HeroSection.astro`, `ProjectCard.astro`
+- Match Figma hierarchy when possible
+- Group related components in folders
+
+---
+
+## Sync Checklist Template
+
+```markdown
+## Design Sync [DATE]
+
+### New Components
+- [ ] Component A - Status
+- [ ] Component B - Status
+
+### Updated Tokens
+- [ ] Colors - checked
+- [ ] Typography - checked
+- [ ] Spacing - checked
+
+### Pages Updated
+- [ ] Page A
+- [ ] Page B
+
+### QA Status
+- [ ] Visual comparison done
+- [ ] Responsive tested
+- [ ] Dark mode verified
+- [ ] Accessibility audited
+
+### Deployed
+- [ ] Commit pushed
+- [ ] Live on production
+```
+
+---
+
+## Resources & References
+
+- **Figma File**: [Link to team Figma]
+- **Design Tokens**: `src/styles/tokens.css`
+- **Component Library**: `src/components/`
+- **Astro Docs**: https://docs.astro.build
+- **Design System**: Warm Editorial Minimalism spec

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,8 +12,7 @@ const projects = allProjects
 	.sort(
 		(a: CollectionEntry<'work'>, b: CollectionEntry<'work'>) =>
 			b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
-	)
-	.slice(0, 3);
+	);
 ---
 
 <BaseLayout title="Ana Monsalve | Developer & Painter" description="Ana Monsalve — Software Development Apprentice at NTT DATA, automation engineer, and artist from Medellín, Colombia.">
@@ -108,9 +107,13 @@ const projects = allProjects
 						projects.map((project, idx) => {
 							const spanishId = project.id.includes('.md') ? project.id.replace('.md', '-es.md') : `${project.id}-es`;
 							const spanishProject = allProjects.find((p) => p.id === spanishId);
-							const slot = `slot-${idx + 1}`;
+							const slot = `slot-${(idx % 3) + 1}`;
+							// A trailing group of exactly 1 project (count % 3 === 1) would
+							// otherwise sit alone in a half-width column with an empty gap
+							// beside it — stretch it full-width instead.
+							const isTrailingSingle = idx === projects.length - 1 && projects.length % 3 === 1;
 							return (
-								<li class:list={['project-item', slot]} data-en-slug={project.id} data-es-slug={spanishId}>
+								<li class:list={['project-item', slot, isTrailingSingle && 'full-span']} data-en-slug={project.id} data-es-slug={spanishId}>
 									<div class="project-en" style="display: block;">
 										<a class="work-card" href={`/work/${project.id}`}>
 											<div class="meta">
@@ -153,7 +156,7 @@ const projects = allProjects
 							);
 						})
 					}
-					<li class="project-item slot-4">
+					<li class="project-item slot-cta">
 						<div class="work-card cta-dark-card">
 							<div class="cta-dark-content">
 								<span class="stars-icon">✦ ✦ ✦</span>
@@ -1152,13 +1155,22 @@ const projects = allProjects
 		.panel-art   { grid-column: span 2; }
 		.panel-roots { grid-column: span 2; }
 
+		/*
+		 * Grid scales to any project count: 2 cols, auto-flow row.
+		 * slot-1/slot-2 (no column span) fill col 1 / col 2 of a row;
+		 * slot-3 spans both columns, so it can't fit next to them and
+		 * auto-placement pushes it (and everything after) to a fresh
+		 * row. The 1-2-3 pattern then repeats every 3 projects without
+		 * any hand-numbered grid-row rules. The CTA card spans full
+		 * width too, so it always lands on its own row at the end.
+		 */
 		.work-bento {
 			grid-template-columns: 1.5fr 1fr;
+			grid-auto-flow: row;
 			gap: 1.25rem;
 		}
 
-		/* slot-1: col 1 row 1 — horizontal (meta left, image right) */
-		.slot-1 { grid-column: 1; grid-row: 1; }
+		/* slot-1: horizontal (meta left, image right) */
 		.slot-1 .work-card {
 			flex-direction: row;
 			min-height: 20rem;
@@ -1174,8 +1186,7 @@ const projects = allProjects
 			position: relative;
 		}
 
-		/* slot-2: col 2 row 1 — vertical */
-		.slot-2 { grid-column: 2; grid-row: 1; }
+		/* slot-2: vertical */
 		.slot-2 .work-card { flex-direction: column; }
 		.slot-2 .img-container {
 			height: 12rem;
@@ -1183,7 +1194,7 @@ const projects = allProjects
 		}
 
 		/* slot-3: full-width landscape — image left, meta right */
-		.slot-3 { grid-column: 1 / -1; grid-row: 2; }
+		.slot-3 { grid-column: 1 / -1; }
 		.slot-3 .work-card {
 			flex-direction: row;
 			min-height: 18rem;
@@ -1199,8 +1210,25 @@ const projects = allProjects
 			padding: 2.2rem;
 		}
 
-		/* slot-4: full-width CTA */
-		.slot-4 { grid-column: 1 / -1; grid-row: 3; }
+		/* CTA: always full-width, always last */
+		.slot-cta { grid-column: 1 / -1; }
+
+		/* Trailing lone project (count % 3 === 1): stretch full-width, no gap beside it */
+		.full-span { grid-column: 1 / -1; }
+		.full-span .work-card {
+			flex-direction: row;
+			min-height: 18rem;
+		}
+		.full-span .meta {
+			flex: 1;
+			justify-content: center;
+			padding: 2.2rem;
+		}
+		.full-span .img-container {
+			flex: 1.1;
+			min-height: 100%;
+			position: relative;
+		}
 
 	}
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded `.slice(0, 3)` on the home page's Work section so it renders every eligible project (not `-es`, not Telas3B), instead of being capped at 3.
- Reworks the `.work-bento` grid to auto-flow: the horizontal/vertical/landscape slot pattern now cycles by `idx % 3` instead of being pinned to fixed grid-row/column positions, so it scales to any project count.
- Handles the edge case where the project count isn't a multiple of 3 — a trailing lone card stretches full-width instead of leaving an empty gap.
- Syncs `.agents/skills/figma-design/` token docs (colors, fonts, spacing) with the real values in `src/styles/tokens.css`, which had drifted.

## Test plan
- [x] Verified in browser at 1440px with the current 4 projects (Ordenary, AstroLink, Hotel Quimbaya, Repostería Buen Corazón) — no gaps, CTA card lands full-width last
- [x] Verified mobile (390px) single-column stacking unaffected
- [x] `npx astro check` — 0 errors